### PR TITLE
Fix sending private ip_addr in HelloLan message

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -81,7 +81,7 @@ impl Application {
                     NetEvent::Message(endpoint, message) => match message {
                         // by udp (multicast):
                         NetMessage::HelloLan(user, server_port) => {
-							let server_addr = format!("{}:{}", endpoint.addr().ip(), server_port);
+							let server_addr = (endpoint.addr().ip(), server_port);
                             if user != self.user_name {
                                 let user_endpoint = self.network.connect_tcp(server_addr).unwrap();
                                 self.network.send(user_endpoint, NetMessage::HelloUser(self.user_name.clone())).unwrap();


### PR DESCRIPTION
Previously HelloLan message contained local server_addr in the form of "0.0.0.0:x", this means that different instance over the lan could not connect to each other. This pr replaces the server_addr in the message with server_port and then reconstructs the server_addr from that port and the endpoint when receiving a HelloLan message.