### PR TITLE
Allow specifying tcp server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ to open the application in your terminal.
 
 By default, your computer user name is used. You can use a different username with `-u <name>`
 
-Also you can modify the multicast discovery address with `-d <address>` 
+You can modify the multicast discovery address with `-d <address>` 
+
+You can set a custom tcp sever port with `-t <port>` 
 
 (see the application help for more info `--help`).
 
@@ -43,4 +45,8 @@ Also you can modify the multicast discovery address with `-d <address>`
 
 ***Q:*** **Hosts are not disoverable**
 
-***A:*** Make sure that no firewall is running (example: ufw), and if that's the case either stop it or add termchat ports to the white list, by default you need to allow port `5877/udp` and `port X/tcp` (currently X is a different with each run)
+***A:*** 
+
+- Make sure that no firewall is running (example: ufw), and if that's the case either stop it or add termchat ports to the white list.
+
+- By default you need to allow port `5877/udp` and `port X/tcp`, `X` is a different with each run. Note that you can specify a custom tcp port as mentioned above and add it to the firewall whitelist.

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,13 @@ fn main() {
                 .help("Multicast address to found others 'termchat' applications"),
         )
         .arg(
+            Arg::with_name("tcp_server_port")
+                .long("tcp-server-port")
+                .short("t")
+                .default_value("0")
+                .help("Tcp server port used when communicating with other termchat instances"),
+        )
+        .arg(
             Arg::with_name("username")
                 .long("username")
                 .short("u")
@@ -31,14 +38,19 @@ fn main() {
         )
         .get_matches();
 
-    let addr = match matches.value_of("discovery").unwrap().parse() {
-        Ok(addr) => addr,
+    let discovery_addr = match matches.value_of("discovery").unwrap().parse() {
+        Ok(discovery_addr) => discovery_addr,
         Err(_) => return eprintln!("'discovery' must be a valid multicast address"),
+    };
+
+    let tcp_server_port = match matches.value_of("tcp_server_port").unwrap().parse() {
+        Ok(port) => port,
+        Err(_) => return eprintln!("Unable to parse tcp server port"),
     };
 
     let name = matches.value_of("username").unwrap();
 
-    if let Ok(mut app) = Application::new(addr, &name) {
+    if let Ok(mut app) = Application::new(discovery_addr, tcp_server_port, &name) {
         app.run()
     }
 }


### PR DESCRIPTION
https://github.com/lemunozm/termchat/issues/4

Turns out specifying a default tcp port server is a bit annoying because you can't just run multiple instances on the same machine (you have to specify a different port each time)

So the alternative is just to keep the automatic tcp port selection while allowing the user to specify a custom one which I think in practice works quite well, since the user can whitelist a specific port(s) and always run termchat with that(those) port(s) specified. 