### PR TITLE
Handle errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm 0.18.0",
+ "lazy_static",
  "message-io",
  "serde",
  "tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ tui = { version = "0.12.0", default-features = false, features = ['crossterm'] }
 whoami = "0.9.0"
 chrono = "0.4.19"
 clap = "2.33.3"
+lazy_static = "1.4.0"

--- a/src/application.rs
+++ b/src/application.rs
@@ -143,6 +143,7 @@ impl Application {
                             state.connected_user(endpoint, &user);
                         }
                         NetMessage::UserMessage(content) => {
+                            // Note: can this unwrap actually fail?
                             let user = "???".to_string();
                             let user = state.user_name(endpoint).unwrap_or(&user);
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,7 +1,7 @@
 use super::state::{ApplicationState, CursorMovement, LogMessage, MessageType, ScrollMovement};
 use super::terminal_events::TerminalEventCollector;
 use super::ui::{self};
-use crate::Result;
+use crate::util::Result;
 
 use crossterm::event::{Event as TermEvent, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::{

--- a/src/application.rs
+++ b/src/application.rs
@@ -49,6 +49,20 @@ impl Application {
         tcp_server_port: u16,
         user_name: &str,
     ) -> Result<Application> {
+        match Self::try_new(discovery_addr, tcp_server_port, user_name) {
+            Ok(app) => Ok(app),
+            Err(e) => {
+                clean_terminal();
+                Err(e)
+            }
+        }
+    }
+
+    fn try_new(
+        discovery_addr: SocketAddr,
+        tcp_server_port: u16,
+        user_name: &str,
+    ) -> Result<Application> {
         let mut event_queue = EventQueue::new();
 
         let sender = event_queue.sender().clone(); // Collect network events
@@ -77,7 +91,14 @@ impl Application {
         })
     }
 
-    pub fn run(&mut self) -> Result<()> {
+    pub fn run(&mut self) {
+        if let Err(e) = self.try_run() {
+            clean_terminal();
+            eprintln!("termchat crashed with err: {}", e);
+        }
+    }
+
+    fn try_run(&mut self) -> Result<()> {
         let mut state = ApplicationState::new();
         ui::draw(&mut self.terminal, &state)?;
 
@@ -211,7 +232,7 @@ impl Drop for Application {
     }
 }
 
-pub fn clean_terminal() {
+fn clean_terminal() {
     io::stdout()
         .execute(terminal::LeaveAlternateScreen)
         .expect("Could not leave alternate screen");

--- a/src/application.rs
+++ b/src/application.rs
@@ -128,13 +128,11 @@ impl Application {
                             state.connected_user(endpoint, &user);
                         }
                         NetMessage::UserMessage(content) => {
-                            // Note: can this unwrap actually fail?
-                            let user = "???".to_string();
-                            let user = state.user_name(endpoint).unwrap_or(&user);
-
-                            let message =
-                                LogMessage::new(user.into(), MessageType::Content(content));
-                            state.add_message(message);
+                            if let Some(user) = state.user_name(endpoint) {
+                                let message =
+                                    LogMessage::new(user.into(), MessageType::Content(content));
+                                state.add_message(message);
+                            }
                         }
                     },
                     NetEvent::AddedEndpoint(_) => (),

--- a/src/application.rs
+++ b/src/application.rs
@@ -97,6 +97,8 @@ impl Application {
         if let Err(e) = self.try_run() {
             clean_terminal();
             eprintln!("termchat crashed with error: {}", e);
+        } else {
+            clean_terminal();
         }
     }
 
@@ -226,22 +228,15 @@ impl Application {
                     TermEvent::Resize(_, _) => (),
                 },
                 Event::Close(e) => {
-                    clean_terminal();
                     if let Some(error) = e {
-                        eprintln!("termchat crashed with error: {}", error);
+                        return Err(error.into());
+                    } else {
+                        return Ok(());
                     }
-                    break;
                 }
             }
             ui::draw(&mut self.terminal, &state)?;
         }
-        Ok(())
-    }
-}
-
-impl Drop for Application {
-    fn drop(&mut self) {
-        clean_terminal();
     }
 }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -108,7 +108,7 @@ impl Application {
                                 };
                                 if let Err(e) = try_connect() {
                                     let message = LogMessage::new(
-                                        format!("{} (me)", self.user_name),
+                                        String::from("termchar :"),
                                         MessageType::Error(e.to_string()),
                                     );
                                     state.add_message(message);
@@ -147,20 +147,20 @@ impl Application {
                         }
                         KeyCode::Enter => {
                             if let Some(input) = state.reset_input() {
-                                let mut message = LogMessage::new(
-                                    format!("{} (me)", self.user_name),
-                                    MessageType::Content(input.clone()),
-                                );
-
-                                if let Err(e) = self.network.send_all(
+                                let message = if let Err(e) = self.network.send_all(
                                     state.all_user_endpoints(),
-                                    NetMessage::UserMessage(input),
+                                    NetMessage::UserMessage(input.clone()),
                                 ) {
-                                    message = LogMessage::new(
-                                        format!("{} (me)", self.user_name),
+                                    LogMessage::new(
+                                        String::from("termchar :"),
                                         MessageType::Error(format_errors(e)),
-                                    );
-                                }
+                                    )
+                                } else {
+                                    LogMessage::new(
+                                        format!("{} (me)", self.user_name),
+                                        MessageType::Content(input),
+                                    )
+                                };
 
                                 state.add_message(message);
                             }

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,7 +1,7 @@
 use super::state::{ApplicationState, CursorMovement, LogMessage, MessageType, ScrollMovement};
 use super::terminal_events::TerminalEventCollector;
 use super::ui::{self};
-use crate::util::{Error, Result};
+use crate::util::{Error, Result, PANIC_LOG_PATH};
 
 use crossterm::event::{Event as TermEvent, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::{
@@ -239,6 +239,12 @@ fn clean_terminal() {
         .execute(terminal::LeaveAlternateScreen)
         .expect("Could not leave alternate screen");
     terminal::disable_raw_mode().expect("Could not disable raw mode at exit");
+    if std::thread::panicking() {
+        eprintln!(
+            "termchat paniced, panic_log is at {}",
+            PANIC_LOG_PATH.display()
+        );
+    }
 }
 
 fn format_errors(e: Vec<(message_io::network::Endpoint, io::Error)>) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,14 @@ mod util;
 
 use application::Application;
 
+#[macro_use]
+extern crate lazy_static;
+
 use clap::{App, Arg};
 
 fn main() {
+    util::set_panic_hook();
+
     let os_username = whoami::username();
 
     let matches = App::new(clap::crate_name!())

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,8 +52,18 @@ fn main() {
 
     let name = matches.value_of("username").unwrap();
 
-    match Application::new(discovery_addr, tcp_server_port, &name) {
-        Ok(mut app) => app.run(),
-        Err(e) => eprintln!("termchat crashed with error: {}", e),
+    let error = match Application::new(discovery_addr, tcp_server_port, &name) {
+        Ok(mut app) => {
+            if let Err(e) = app.run() {
+                Some(e)
+            } else {
+                None
+            }
+        }
+        Err(e) => Some(e),
+    };
+    if let Some(e) = error {
+        // app is now dropped we can print to stderr safely
+        eprintln!("termchat crashed with error: {}", e);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,15 +55,7 @@ fn main() {
     let name = matches.value_of("username").unwrap();
 
     match Application::new(discovery_addr, tcp_server_port, &name) {
-        Ok(mut app) => {
-            if let Err(e) = app.run() {
-                application::clean_terminal();
-                eprintln!("Termchat crashed, err: {}", e);
-            }
-        }
-        Err(e) => {
-            application::clean_terminal();
-            eprintln!("Termchat crashed, err: {}", e);
-        }
+        Ok(mut app) => app.run(),
+        Err(e) => eprintln!("termchat crashed with error: {}", e),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,6 @@ use application::Application;
 
 use clap::{App, Arg};
 
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
-
 fn main() {
     let os_username = whoami::username();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,6 +8,7 @@ pub enum MessageType {
     Connection,
     Disconnection,
     Content(String),
+    Error(String),
 }
 
 pub struct LogMessage {
@@ -100,7 +101,8 @@ impl ApplicationState {
     }
 
     pub fn disconnected_user(&mut self, endpoint: Endpoint) {
-        let user = self.lan_users.remove(&endpoint).unwrap();
+        let user = "???".to_string();
+        let user = self.lan_users.remove(&endpoint).unwrap_or(user);
         self.add_message(LogMessage::new(user, MessageType::Disconnection));
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -101,9 +101,11 @@ impl ApplicationState {
     }
 
     pub fn disconnected_user(&mut self, endpoint: Endpoint) {
-        let user = "???".to_string();
-        let user = self.lan_users.remove(&endpoint).unwrap_or(user);
-        self.add_message(LogMessage::new(user, MessageType::Disconnection));
+        if self.lan_users.contains_key(&endpoint) {
+            // unwrap is safe because of the check above
+            let user = self.lan_users.remove(&endpoint).unwrap();
+            self.add_message(LogMessage::new(user, MessageType::Disconnection));
+        }
     }
 
     pub fn input_write(&mut self, character: char) {

--- a/src/terminal_events.rs
+++ b/src/terminal_events.rs
@@ -35,17 +35,8 @@ impl TerminalEventCollector {
                         Ok(())
                     };
                     while running.load(Ordering::Relaxed) {
-                        if let Err(e) = try_read() {
-                            crate::application::clean_terminal();
-                            eprintln!("Termchat crashed, could not read input event, error: {}", e);
-
-                            // Hack send to ctrlc to the main thread to exit with clean up
-                            event_callback(crossterm::event::Event::Key(
-                                crossterm::event::KeyEvent {
-                                    code: crossterm::event::KeyCode::Char('c'),
-                                    modifiers: crossterm::event::KeyModifiers::CONTROL,
-                                },
-                            ))
+                        if let Err(_e) = try_read() {
+                            // handle e
                         }
                     }
                 })

--- a/src/terminal_events.rs
+++ b/src/terminal_events.rs
@@ -1,4 +1,4 @@
-use crate::Result;
+use crate::util::Result;
 use crossterm::event::Event;
 
 use std::sync::{

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -31,13 +31,7 @@ fn draw_messages_panel(
     state: &ApplicationState,
     chunk: Rect,
 ) {
-    const MESSAGE_COLORS: [Color; 5] = [
-        Color::Blue,
-        Color::Yellow,
-        Color::Red,
-        Color::Cyan,
-        Color::Magenta,
-    ];
+    const MESSAGE_COLORS: [Color; 4] = [Color::Blue, Color::Yellow, Color::Cyan, Color::Magenta];
 
     let messages = state
         .messages()
@@ -69,8 +63,8 @@ fn draw_messages_panel(
                 ]),
                 MessageType::Error(error) => Spans::from(vec![
                     Span::styled(date, Style::default().fg(Color::DarkGray)),
-                    Span::styled("termchat error: ", Style::default().fg(Color::LightRed)),
-                    Span::styled(error, Style::default().fg(Color::Red)),
+                    Span::styled(&message.user, Style::default().fg(Color::Red)),
+                    Span::styled(error, Style::default().fg(Color::LightRed)),
                 ]),
             }
         })

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,6 @@
 use super::state::{ApplicationState, MessageType};
 use super::util::SplitEach;
-use crate::Result;
+use crate::util::Result;
 
 use tui::backend::CrosstermBackend;
 use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,6 @@
 use super::state::{ApplicationState, MessageType};
 use super::util::SplitEach;
+use crate::Result;
 
 use tui::backend::CrosstermBackend;
 use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
@@ -10,18 +11,19 @@ use tui::{Frame, Terminal};
 
 use std::io::Stdout;
 
-pub fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &ApplicationState) {
-    terminal
-        .draw(|frame| {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(0), Constraint::Length(6)].as_ref())
-                .split(frame.size());
+pub fn draw(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    state: &ApplicationState,
+) -> Result<()> {
+    Ok(terminal.draw(|frame| {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(0), Constraint::Length(6)].as_ref())
+            .split(frame.size());
 
-            draw_messages_panel(frame, state, chunks[0]);
-            draw_input_panel(frame, state, chunks[1]);
-        })
-        .unwrap()
+        draw_messages_panel(frame, state, chunks[0]);
+        draw_input_panel(frame, state, chunks[1]);
+    })?)
 }
 
 fn draw_messages_panel(
@@ -64,6 +66,11 @@ fn draw_messages_panel(
                     Span::styled(&message.user, Style::default().fg(color)),
                     Span::styled(": ", Style::default().fg(color)),
                     Span::raw(content),
+                ]),
+                MessageType::Error(error) => Spans::from(vec![
+                    Span::styled(date, Style::default().fg(Color::DarkGray)),
+                    Span::styled("termchat error: ", Style::default().fg(Color::LightRed)),
+                    Span::styled(error, Style::default().fg(Color::Red)),
                 ]),
             }
         })

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,18 @@
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, Error>;
 
+lazy_static! {
+    static ref TERMCHAT_TEMP: std::path::PathBuf = std::env::temp_dir().join("termchat");
+    pub static ref PANIC_LOG_PATH: std::path::PathBuf = TERMCHAT_TEMP.join("panic_log");
+}
+
+pub fn set_panic_hook() {
+    std::panic::set_hook(Box::new(|panic_info| {
+        let _ = std::fs::create_dir_all(&*TERMCHAT_TEMP);
+        let _ = std::fs::write(&*PANIC_LOG_PATH, panic_info.to_string());
+    }));
+}
+
 pub trait SplitEach {
     fn split_each(&self, n: usize) -> Vec<&Self>;
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
-pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 pub trait SplitEach {
     fn split_each(&self, n: usize) -> Vec<&Self>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
 pub trait SplitEach {
     fn split_each(&self, n: usize) -> Vec<&Self>;
 }


### PR DESCRIPTION
This pr handle all errors on termchat.

It makes the distinction between recoverable and non recoverable errors.

Recoverable errors are printed as messages.
Unrecoverable errors terminate the program gracefully while making sure to clean up.

For recoverable errors these two:
https://github.com/sigmaSd/termchat/blob/error_handling/src/application.rs#L94
https://github.com/sigmaSd/termchat/blob/error_handling/src/application.rs#L147

Also when we add sending files it should be added to this category.

The rest is unrecoverable.


/////
/////

Note: 
This pr use a format_err function to stringify the errors produced here https://github.com/lemunozm/message-io/blob/master/src/network.rs#L194 I think it might be better if this function returned a new type instead.
example: `Struct SendAllErrors(Vec<(Endpoint, io::Error))`.
The benefit is we can then impl `std::error::Error` on it, so it can be simply handled with `?` instead of a custom function.