### PR TITLE
Remove custom panic hook in order to get backtraces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,6 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm 0.18.0",
- "lazy_static",
  "message-io",
  "serde",
  "tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,3 @@ tui = { version = "0.12.0", default-features = false, features = ['crossterm'] }
 whoami = "0.9.0"
 chrono = "0.4.19"
 clap = "2.33.3"
-lazy_static = "1.4.0"

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,7 +1,7 @@
 use super::state::{ApplicationState, CursorMovement, LogMessage, MessageType, ScrollMovement};
 use super::terminal_events::TerminalEventCollector;
 use super::ui::{self};
-use crate::util::{Error, Result, PANIC_LOG_PATH};
+use crate::util::{Error, Result};
 
 use crossterm::event::{Event as TermEvent, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::{
@@ -241,8 +241,7 @@ fn clean_terminal() {
     terminal::disable_raw_mode().expect("Could not disable raw mode at exit");
     if std::thread::panicking() {
         eprintln!(
-            "termchat paniced, panic_log is at {}",
-            PANIC_LOG_PATH.display()
+            "termchat paniced, to log the error you can redirect stderror to a file, example: `termchat 2>termchat_log`"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,9 @@ mod util;
 
 use application::Application;
 
-#[macro_use]
-extern crate lazy_static;
-
 use clap::{App, Arg};
 
 fn main() {
-    util::set_panic_hook();
-
     let os_username = whoami::username();
 
     let matches = App::new(clap::crate_name!())
@@ -69,6 +64,6 @@ fn main() {
     };
     if let Some(e) = error {
         // app is now dropped we can print to stderr safely
-        eprintln!("termchat crashed with error: {}", e);
+        eprintln!("termchat exited with error: {}", e);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,18 +1,6 @@
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, Error>;
 
-lazy_static! {
-    static ref TERMCHAT_TEMP: std::path::PathBuf = std::env::temp_dir().join("termchat");
-    pub static ref PANIC_LOG_PATH: std::path::PathBuf = TERMCHAT_TEMP.join("panic_log");
-}
-
-pub fn set_panic_hook() {
-    std::panic::set_hook(Box::new(|panic_info| {
-        let _ = std::fs::create_dir_all(&*TERMCHAT_TEMP);
-        let _ = std::fs::write(&*PANIC_LOG_PATH, panic_info.to_string());
-    }));
-}
-
 pub trait SplitEach {
     fn split_each(&self, n: usize) -> Vec<&Self>;
 }


### PR DESCRIPTION
Unfortunately with panic hook we loose backtracks, so for now we better keep the default one and just a print a "helpful" message.