### PR TITLE
Update README.md about AUR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ $ cargo install termchat
 ```
 If you have `~/.cargo/bin` in your PATH (or similar in your OS), you will be able to use *termchat* everywhere in your computer!
 
+## Arch Linux
+
+`termchat` can be installed from available [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=termchat&outdated=&SB=n&SO=a&PP=50&do_Search=Go) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
+
+```sh
+$ yay -S termchat
+```
+
+If you prefer, you can clone the [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=termchat&outdated=&SB=n&SO=a&PP=50&do_Search=Go) and then compile them with [makepkg](https://wiki.archlinux.org/index.php/Makepkg). For example,
+
+```sh
+$ git clone https://aur.archlinux.org/termchat.git && cd termchat && makepkg -si
+```
+
 [cargo]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 
 # How it works?


### PR DESCRIPTION
Hey,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following packages for the installation of `termchat` on Arch Linux and other distributions that support installing packages from [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository):

* [termchat](https://aur.archlinux.org/packages/termchat/) (builds from source)
* [termchat-git](https://aur.archlinux.org/packages/termchat-git/) (VCS/development package)

PS: I can create a `-bin` package if you provide a pre-compiled x86_64 binary along with the release artifacts.

I also updated README.md about installation from AUR. (bec49a2)

Regards,
orhun.