### PR TITLE
Add send files command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "message-io"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ec12b1f854f0621ea36ac00ebdf6251bee4b609fa321bc0a5ca5892cb7c017"
+checksum = "1611cefcffb1416128fcd0ab8a4e71b19f95915221c7eeeba596543106b1b4c4"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities", "command-line-interface"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-message-io = "0.4.3"
+message-io = "0.4.4"
 serde = { version = "1.0.116", features = ["derive"] }
 crossterm = "0.18.0"
 tui = { version = "0.12.0", default-features = false, features = ['crossterm'] }

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ You can set a custom tcp sever port with `-t <port>`
 ### Commands
 Termchat treats messages containings the following commands in a special way:
 
-- **?send** *<$path_to_file>* -> Sends the specified file to everyone on the network, exp: `?send ./myfile`
+- **?send** *<$path_to_file>* **->** sends the specified file to everyone on the network, exp: `?send ./myfile`
 
 
-## Frequently Asked Questions
+**Frequently Asked Questions**
 
 ***Q:*** **Hosts are not disoverable**
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ You can set a custom tcp sever port with `-t <port>`
 
 (see the application help for more info `--help`).
 
+### Commands
+Termchat treats messages containings the following commands in a special way:
+
+- **?send** *<$path_to_file>* -> Sends the specified file to everyone on the network, exp: `?send ./myfile`
+
+
 ## Frequently Asked Questions
 
 ***Q:*** **Hosts are not disoverable**

--- a/src/application.rs
+++ b/src/application.rs
@@ -298,7 +298,7 @@ impl Application {
             state.progress.start(file_size);
 
             let mut file = std::fs::File::open(path)?;
-            const BLOCK: usize = 32768;
+            const BLOCK: usize = 65536;
             let mut data = [0; BLOCK];
 
             loop {

--- a/src/application/commands.rs
+++ b/src/application/commands.rs
@@ -1,0 +1,79 @@
+use super::{stringify_sendall_errors, Application, NetMessage};
+use crate::state::{ApplicationState, LogMessage, MessageType};
+use crate::ui;
+use crate::util::Result;
+
+impl Application {
+    pub fn parse_input(&mut self, input: &str, state: &mut ApplicationState) -> Result<()> {
+        const SEND_COMMAND: &str = "?send";
+        if input.starts_with(SEND_COMMAND) {
+            self.handle_send_command(input, state)?;
+        }
+        Ok(())
+    }
+
+    fn handle_send_command(&mut self, input: &str, state: &mut ApplicationState) -> Result<()> {
+        use std::io::Read;
+        const READ_FILENAME_ERROR: &str = "Unable to read file name";
+
+        let path =
+            std::path::Path::new(input.split_whitespace().nth(1).ok_or("No file specified")?);
+        let file_name = path
+            .file_name()
+            .ok_or(READ_FILENAME_ERROR)?
+            .to_str()
+            .ok_or(READ_FILENAME_ERROR)?
+            .to_string();
+
+        use std::convert::TryInto;
+        let file_size = std::fs::metadata(path)?.len().try_into()?;
+        state.progress.start(file_size);
+
+        let mut file = std::fs::File::open(path)?;
+        const BLOCK: usize = 65536;
+        let mut data = [0; BLOCK];
+
+        loop {
+            match file.read(&mut data) {
+                Ok(bytes_read) => {
+                    state.progress.advance(bytes_read);
+                    let data_to_send = data[..bytes_read].to_vec();
+
+                    self.network
+                        .send_all(
+                            state.all_user_endpoints(),
+                            NetMessage::UserData(
+                                file_name.clone(),
+                                Some((data_to_send, bytes_read)),
+                                None,
+                            ),
+                        )
+                        .map_err(stringify_sendall_errors)?;
+
+                    // done
+                    if bytes_read == 0 {
+                        let msg = format!("Successfully sent file {} !", file_name);
+                        let msg = LogMessage::new("Termchat".into(), MessageType::Content(msg));
+                        state.add_message(msg);
+                        break;
+                    }
+                }
+                Err(e) => {
+                    state.progress.done();
+
+                    self.network
+                        .send_all(
+                            state.all_user_endpoints(),
+                            NetMessage::UserData(file_name, None, Some(e.to_string())),
+                        )
+                        .map_err(stringify_sendall_errors)?;
+                    return Err(e.into());
+                }
+            }
+            ui::draw(&mut self.terminal, &state)?;
+        }
+        state.progress.done();
+        ui::draw(&mut self.terminal, &state)?;
+        Ok(())
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -35,6 +35,32 @@ pub struct ApplicationState {
     lan_users: HashMap<Endpoint, String>,
     users_id: HashMap<String, usize>,
     last_user_id: usize,
+    pub progress: Progress,
+}
+
+pub struct Progress {
+    max: usize,
+    current: usize,
+    state: ProgressState,
+}
+enum ProgressState {
+    Idle,
+    Working,
+    Done,
+}
+
+impl Progress {
+    pub fn start(&mut self, max: usize) {
+        self.state = ProgressState::Working;
+        self.max = max;
+    }
+    pub fn advance(&mut self, n: usize) {
+        self.current += n;
+    }
+    pub fn done(&mut self) {
+        self.state = ProgressState::Done;
+        self.current = 0;
+    }
 }
 
 pub enum CursorMovement {
@@ -60,6 +86,11 @@ impl ApplicationState {
             lan_users: HashMap::new(),
             users_id: HashMap::new(),
             last_user_id: 0,
+            progress: Progress {
+                max: 0,
+                current: 0,
+                state: ProgressState::Idle,
+            },
         }
     }
 
@@ -195,5 +226,13 @@ impl ApplicationState {
 
     pub fn add_message(&mut self, message: LogMessage) {
         self.messages.push(message);
+    }
+
+    pub fn progress(&self) -> Option<(usize, usize)> {
+        if let ProgressState::Working = self.progress.state {
+            Some((self.progress.current, self.progress.max))
+        } else {
+            None
+        }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,11 +4,19 @@ use chrono::{DateTime, Local};
 
 use std::collections::HashMap;
 
+use crate::util::{Progress, ProgressState};
+
 pub enum MessageType {
     Connection,
     Disconnection,
     Content(String),
-    Error(String),
+    Termchat(String, TermchatMessageType),
+}
+
+#[derive(PartialEq)]
+pub enum TermchatMessageType {
+    Error,
+    Notification,
 }
 
 pub struct LogMessage {
@@ -38,31 +46,6 @@ pub struct ApplicationState {
     pub progress: Progress,
 }
 
-pub struct Progress {
-    max: usize,
-    current: usize,
-    state: ProgressState,
-}
-enum ProgressState {
-    Idle,
-    Working,
-    Done,
-}
-
-impl Progress {
-    pub fn start(&mut self, max: usize) {
-        self.state = ProgressState::Working;
-        self.max = max;
-    }
-    pub fn advance(&mut self, n: usize) {
-        self.current += n;
-    }
-    pub fn done(&mut self) {
-        self.state = ProgressState::Done;
-        self.current = 0;
-    }
-}
-
 pub enum CursorMovement {
     Left,
     Right,
@@ -86,11 +69,7 @@ impl ApplicationState {
             lan_users: HashMap::new(),
             users_id: HashMap::new(),
             last_user_id: 0,
-            progress: Progress {
-                max: 0,
-                current: 0,
-                state: ProgressState::Idle,
-            },
+            progress: Progress::default(),
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,7 +33,7 @@ fn draw_messages_panel(
 ) {
     const MESSAGE_COLORS: [Color; 4] = [Color::Blue, Color::Yellow, Color::Cyan, Color::Magenta];
 
-    let messages = state
+    let mut messages = state
         .messages()
         .iter()
         .rev()
@@ -72,6 +72,24 @@ fn draw_messages_panel(
             }
         })
         .collect::<Vec<_>>();
+
+    if let Some((current, max)) = state.progress() {
+        let color = Color::Red;
+
+        let width = chunk.width - 20;
+        let ui_step = width as f32 / max as f32;
+        let ui_current = (current as f32 * ui_step) as usize;
+        let ui_remaining = ((max.saturating_sub(current)) as f32 * ui_step) as usize;
+
+        let current: String = std::iter::repeat("#").take(ui_current).collect();
+        let remaining: String = std::iter::repeat("-").take(ui_remaining).collect();
+        let msg = format!("[{}{}]", current, remaining);
+        let ui_message = vec![
+            Span::styled("Termchat: ", Style::default().fg(color)),
+            Span::styled(msg, Style::default().fg(color)),
+        ];
+        messages.insert(0, Spans::from(ui_message));
+    }
 
     let messages_panel = Paragraph::new(messages)
         .block(Block::default().borders(Borders::ALL).title(Span::styled(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -55,12 +55,15 @@ fn draw_messages_panel(
                     Span::styled(&message.user, Style::default().fg(color)),
                     Span::styled(" is offline", Style::default().fg(color)),
                 ]),
-                MessageType::Content(content) => Spans::from(vec![
-                    Span::styled(date, Style::default().fg(Color::DarkGray)),
-                    Span::styled(&message.user, Style::default().fg(color)),
-                    Span::styled(": ", Style::default().fg(color)),
-                    Span::raw(content),
-                ]),
+                MessageType::Content(content) => {
+                    let mut ui_message = vec![
+                        Span::styled(date, Style::default().fg(Color::DarkGray)),
+                        Span::styled(&message.user, Style::default().fg(color)),
+                        Span::styled(": ", Style::default().fg(color)),
+                    ];
+                    ui_message.extend(parse_content(content));
+                    Spans::from(ui_message)
+                }
                 MessageType::Error(error) => Spans::from(vec![
                     Span::styled(date, Style::default().fg(Color::DarkGray)),
                     Span::styled(&message.user, Style::default().fg(Color::Red)),
@@ -81,6 +84,27 @@ fn draw_messages_panel(
         .wrap(Wrap { trim: false });
 
     frame.render_widget(messages_panel, chunk);
+}
+
+fn parse_content<'a>(content: &'a str) -> Vec<Span<'a>> {
+    const SEND_COMMAND: &str = "?send";
+
+    if content.starts_with(SEND_COMMAND) {
+        content
+            .splitn(2, SEND_COMMAND)
+            .enumerate()
+            .map(|(index, part)| {
+                // ?send
+                if index == 0 {
+                    Span::styled(SEND_COMMAND, Style::default().fg(Color::LightYellow))
+                } else {
+                    Span::raw(part)
+                }
+            })
+            .collect()
+    } else {
+        vec![Span::raw(content)]
+    }
 }
 
 fn draw_input_panel(

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,4 @@
-pub type Error = Box<dyn std::error::Error + Send + Sync>;
-pub type Result<T> = std::result::Result<T, Error>;
-
+// split messages to fit the width of the ui panel
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 pub fn split_each(input: String, width: usize) -> Vec<String> {
     let mut splitted = Vec::with_capacity(input.width() / width);
@@ -22,4 +20,69 @@ pub fn split_each(input: String, width: usize) -> Vec<String> {
         splitted.push(row.drain(..).collect());
     }
     splitted
+}
+
+// Termchat messages convenience function
+use crate::state::{LogMessage, MessageType, TermchatMessageType};
+pub fn termchat_message(content: String, msg_type: TermchatMessageType) -> LogMessage {
+    LogMessage::new(
+        "Termchat: ".into(),
+        MessageType::Termchat(content, msg_type),
+    )
+}
+
+// Errors
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub fn stringify_sendall_errors(e: Vec<(message_io::network::Endpoint, std::io::Error)>) -> String {
+    let mut out = String::new();
+    for (endpoint, error) in e {
+        let msg = format!("Failed to connect to {}, error: {}", endpoint, error);
+        out.push_str(&msg);
+        out.push('\n');
+    }
+    // remove last new line
+    if !out.is_empty() {
+        out.pop();
+    }
+    out
+}
+
+// Progress bar handling
+#[derive(Default)]
+pub struct Progress {
+    pub max: usize,
+    pub current: usize,
+    pub state: ProgressState,
+}
+
+#[derive(PartialEq)]
+pub enum ProgressState {
+    Idle,
+    Working,
+}
+
+impl Default for ProgressState {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+impl Progress {
+    pub fn start(&mut self, max: usize) {
+        debug_assert!(self.state == ProgressState::Idle);
+        self.max = max;
+        self.state = ProgressState::Working;
+    }
+
+    pub fn advance(&mut self, n: usize) {
+        debug_assert!(self.state == ProgressState::Working);
+        self.current += n;
+    }
+
+    pub fn done(&mut self) {
+        debug_assert!(self.state == ProgressState::Working);
+        *self = Self::default();
+    }
 }


### PR DESCRIPTION
This PR add the ability to send files with `?send $path` command

- it sends file in chunks
- displays a progress bar
- shows a notification for the receiver and sender when done

For some reason using 2^15 for the read buffer made termchat not hit the bad paths and sending actually works, I tested with a 200Mb file (I'll need probably to test more) https://github.com/sigmaSd/termchat/blob/send_in_chunks_with_progress/src/application.rs#L301

Using a bigger buffer results in crashing, using smaller one results in silent failure which is probably related to https://github.com/lemunozm/message-io/issues/3
