### PR TITLE
Support sending files of quoted or escaped path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,7 +555,7 @@ dependencies = [
  "cloudabi",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec",
  "winapi",
 ]
@@ -625,6 +646,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.4",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +733,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
+dependencies = [
+ "dirs-next",
+]
+
+[[package]]
+name = "shellwords"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e515aa4699a88148ed5ef96413ceef0048ce95b43fbc955a33bde0a70fcae6"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +791,7 @@ checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi",
 ]
 
@@ -764,6 +823,8 @@ dependencies = [
  "rand",
  "resize",
  "serde",
+ "shellexpand",
+ "shellwords",
  "tui",
  "unicode-width",
  "v4l",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ chrono = "0.4.19"
 clap = "2.33.3"
 unicode-width = "0.1.8"
 resize = "0.5.5"
+shellwords = "1.1.0"
+shellexpand = "2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 v4l = { version = "0.12.0", optional = true }

--- a/src/application.rs
+++ b/src/application.rs
@@ -84,7 +84,8 @@ impl<'a> Application<'a> {
         let (_, server_addr) = self.network.listen(Transport::Tcp, server_addr)?;
         self.network.listen(Transport::Udp, self.config.discovery_addr)?;
 
-        let discovery_endpoint = self.network.connect(Transport::Udp, self.config.discovery_addr)?;
+        let discovery_endpoint =
+            self.network.connect(Transport::Udp, self.config.discovery_addr)?;
         let message = NetMessage::HelloLan(self.config.user_name.clone(), server_addr.port());
         self.network.send(discovery_endpoint, message);
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap};
 
 pub trait Command {
     fn name(&self) -> &'static str;
-    fn parse_params(&self, param: Option<&str>) -> Result<Box<dyn Action>>;
+    fn parse_params(&self, params: Vec<String>) -> Result<Box<dyn Action>>;
 }
 
 #[derive(Default)]
@@ -30,7 +30,11 @@ impl CommandManager {
             let mut input = input.splitn(2, char::is_whitespace);
             if let Some(first) = input.next() {
                 if let Some(parser) = self.parsers.get(first) {
-                    return Some(parser.parse_params(input.next()))
+                    let param_str = input.next().unwrap_or("");
+                    return match shellwords::split(param_str) {
+                        Ok(params) => Some(parser.parse_params(params)),
+                        Err(err) => Some(Err(err.into())),
+                    }
                 }
             }
         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap};
 
 pub trait Command {
     fn name(&self) -> &'static str;
-    fn parse_params(&self, params: &[&str]) -> Result<Box<dyn Action>>;
+    fn parse_params(&self, param: Option<&str>) -> Result<Box<dyn Action>>;
 }
 
 #[derive(Default)]
@@ -27,10 +27,10 @@ impl CommandManager {
 
     pub fn find_command_action(&self, input: &str) -> Option<Result<Box<dyn Action>>> {
         if let Some(input) = input.strip_prefix(Self::COMMAND_PREFIX) {
-            let params = input.split_whitespace().collect::<Vec<_>>();
-            if let Some((first, rest)) = params.split_first() {
+            let mut input = input.splitn(2, char::is_whitespace);
+            if let Some(first) = input.next() {
                 if let Some(parser) = self.parsers.get(first) {
-                    return Some(parser.parse_params(rest))
+                    return Some(parser.parse_params(input.next()))
                 }
             }
         }

--- a/src/commands/send_file.rs
+++ b/src/commands/send_file.rs
@@ -16,9 +16,12 @@ impl Command for SendFileCommand {
         "send"
     }
 
-    fn parse_params(&self, params: &[&str]) -> Result<Box<dyn Action>> {
-        let file_path = params.get(0).ok_or("No file specified")?;
-        match SendFile::new(file_path) {
+    fn parse_params(&self, param: Option<&str>) -> Result<Box<dyn Action>> {
+        let param = param.ok_or("No file specified")?;
+        let words = shellwords::split(param)?;
+        let s = words.get(0).ok_or("No file specified")?;
+        let file_path = shellexpand::full(s)?;
+        match SendFile::new(&file_path) {
             Ok(action) => Ok(Box::new(action)),
             Err(e) => Err(e),
         }

--- a/src/commands/send_file.rs
+++ b/src/commands/send_file.rs
@@ -16,11 +16,9 @@ impl Command for SendFileCommand {
         "send"
     }
 
-    fn parse_params(&self, param: Option<&str>) -> Result<Box<dyn Action>> {
-        let param = param.ok_or("No file specified")?;
-        let words = shellwords::split(param)?;
-        let s = words.get(0).ok_or("No file specified")?;
-        let file_path = shellexpand::full(s)?;
+    fn parse_params(&self, params: Vec<String>) -> Result<Box<dyn Action>> {
+        let param = params.get(0).ok_or("No file specified")?;
+        let file_path = shellexpand::full(param)?;
         match SendFile::new(&file_path) {
             Ok(action) => Ok(Box::new(action)),
             Err(e) => Err(e),

--- a/src/commands/send_stream/linux.rs
+++ b/src/commands/send_stream/linux.rs
@@ -19,7 +19,7 @@ impl Command for SendStreamCommand {
         "startstream"
     }
 
-    fn parse_params(&self, _param: Option<&str>) -> Result<Box<dyn Action>> {
+    fn parse_params(&self, _params: Vec<String>) -> Result<Box<dyn Action>> {
         match SendStream::new() {
             Ok(action) => Ok(Box::new(action)),
             Err(e) => Err(e),
@@ -101,7 +101,7 @@ impl Command for StopStreamCommand {
         "stopstream"
     }
 
-    fn parse_params(&self, _param: Option<&str>) -> Result<Box<dyn Action>> {
+    fn parse_params(&self, _params: Vec<String>) -> Result<Box<dyn Action>> {
         Ok(Box::new(StopStream {}))
     }
 }

--- a/src/commands/send_stream/linux.rs
+++ b/src/commands/send_stream/linux.rs
@@ -19,7 +19,7 @@ impl Command for SendStreamCommand {
         "startstream"
     }
 
-    fn parse_params(&self, _params: &[&str]) -> Result<Box<dyn Action>> {
+    fn parse_params(&self, _param: Option<&str>) -> Result<Box<dyn Action>> {
         match SendStream::new() {
             Ok(action) => Ok(Box::new(action)),
             Err(e) => Err(e),
@@ -101,7 +101,7 @@ impl Command for StopStreamCommand {
         "stopstream"
     }
 
-    fn parse_params(&self, _params: &[&str]) -> Result<Box<dyn Action>> {
+    fn parse_params(&self, _param: Option<&str>) -> Result<Box<dyn Action>> {
         Ok(Box::new(StopStream {}))
     }
 }

--- a/src/commands/send_stream/other.rs
+++ b/src/commands/send_stream/other.rs
@@ -9,7 +9,7 @@ impl Command for SendStreamCommand {
         "stream"
     }
 
-    fn parse_params(&self, _param: Option<&str>) -> Result<Box<dyn Action>> {
+    fn parse_params(&self, _params: Vec<String>) -> Result<Box<dyn Action>> {
         Err(format!("{} command is not supported on this platform.", self.name()).into())
     }
 }
@@ -19,7 +19,7 @@ impl Command for StopStreamCommand {
         "stopstream"
     }
 
-    fn parse_params(&self, _param: Option<&str>) -> Result<Box<dyn Action>> {
+    fn parse_params(&self, _params: Vec<String>) -> Result<Box<dyn Action>> {
         Err(format!("{} command is not supported on this platform.", self.name()).into())
     }
 }

--- a/src/commands/send_stream/other.rs
+++ b/src/commands/send_stream/other.rs
@@ -9,7 +9,7 @@ impl Command for SendStreamCommand {
         "stream"
     }
 
-    fn parse_params(&self, _params: &[&str]) -> Result<Box<dyn Action>> {
+    fn parse_params(&self, _param: Option<&str>) -> Result<Box<dyn Action>> {
         Err(format!("{} command is not supported on this platform.", self.name()).into())
     }
 }
@@ -19,7 +19,7 @@ impl Command for StopStreamCommand {
         "stopstream"
     }
 
-    fn parse_params(&self, _params: &[&str]) -> Result<Box<dyn Action>> {
+    fn parse_params(&self, _param: Option<&str>) -> Result<Box<dyn Action>> {
         Err(format!("{} command is not supported on this platform.", self.name()).into())
     }
 }


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

Can not send a file with spaces in its path. This PR will fix it.

Assumed I have a file:
```sh
 ➜  ~ touch 'a b'
```

with this patch I can send it via one of:
```
?send ~/a\ b
?send "~/a b"
?send "$HOME/a b"
?send $HOME/a\ b
...
```