### PR TITLE
bugfix

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -235,8 +235,12 @@ impl<'a> Application<'a> {
 
                                 match action {
                                     Some(action) => self.process_action(action),
-                                    None => String::from("This command doesn't exists")
-                                        .report_err(&mut self.state),
+                                    None => {
+                                        if input.starts_with('?') {
+                                            String::from("This command doesn't exists")
+                                                .report_err(&mut self.state);
+                                        }
+                                    }
                                 }
                             }
                             Err(error) => {


### PR DESCRIPTION
Hello, 

The last commit introduced a bug, any normal message (that is not a command)  will print "This command doesn't exists".

This is a quickfix.